### PR TITLE
DispalyObjectContainer._swapChildrenAt性能问题

### DIFF
--- a/src/egret/display/DisplayObjectContainer.ts
+++ b/src/egret/display/DisplayObjectContainer.ts
@@ -273,11 +273,9 @@ module egret {
             var list:Array<DisplayObject> = this._children;
             var child1:DisplayObject = list[index1];
             var child2:DisplayObject = list[index2];
-            list.splice(index2, 1);
-            list.splice(index1, 1);
-
-            list.splice(index1, 0, child2);
-            list.splice(index2, 0, child1);
+            
+            list[index1] = child2;
+            list[index2] = child1;
         }
 
         /**


### PR DESCRIPTION
看到代码里连续使用了4次splice，是否可以直接设置index来替代。在numChildren较大，index1，index2较小的时候加快速度。
