### PR TITLE
egret publish脚本支持Java 8

### DIFF
--- a/tools/lib/tools/publish.js
+++ b/tools/lib/tools/publish.js
@@ -86,7 +86,7 @@ ClosureCompiler.getBundledJava = function () {
 ClosureCompiler.testJava = function (java, callback) {
     child_process.exec('"' + java + '" -version', {}, function (error, stdout, stderr) {
         stderr += "";
-        if (stderr.indexOf("version \"1.7.") >= 0) {
+        if (stderr.indexOf("version \"1.7.") >= 0 || stderr.indexOf("version \"1.8.") >= 0) {
             callback(true, null);
         } else if (stderr.indexOf("version \"") >= 0) {
             callback(false, new Error("Not Java 7"));


### PR DESCRIPTION
微调了ClosureCompiler的testJava()方法，hardcode支持Java 8
