### PR TITLE
文字重新赋值无效

### DIFF
--- a/src/egret/text/BitmapText.ts
+++ b/src/egret/text/BitmapText.ts
@@ -79,9 +79,9 @@ module egret {
                     var bitmap = this._bitmapPool[i];
                     if (!bitmap) {
                         bitmap = new Bitmap();
-                        bitmap.texture = texture;
                         this._bitmapPool.push(bitmap);
                     }
+                    bitmap.texture = texture;
                     this.addChild(bitmap);
                     bitmap.x = rect.width;
                 }


### PR DESCRIPTION
Bitmap.text = "aaa";第一遍显示是正确的。
Bitmap.text = "bbb";重新赋值还显示aaa
源代码里new bitmap的时候才替换材质，应该放在new的外面
