### PR TITLE
spritSheet解析的时候没有传递偏移量

### DIFF
--- a/src/extension/resource/analyzer/SheetAnalyzer.ts
+++ b/src/extension/resource/analyzer/SheetAnalyzer.ts
@@ -122,7 +122,7 @@ module RES {
             var spriteSheet:egret.SpriteSheet = new egret.SpriteSheet(texture);
             for(var name in frames){
                 var config:any = frames[name];
-                spriteSheet.createTexture(name,config.x,config.y,config.w,config.h);
+                spriteSheet.createTexture(name,config.x,config.y,config.w,config.h,config.offX, config.offY);
             }
             return spriteSheet;
         }


### PR DESCRIPTION
当图像有透明区域的时候，材质打包工具都会把透明区域裁掉，会有一个偏移量参数。
SheetAnalyzer没有把偏移量传递给Texture._offsetX。
shoeBox里的偏移量参数是offX。不知道其他材质工具的参数是什么名字，最好统一一下
