### PR TITLE
扩充drawCircle方法：增加两个可选参数sAngle和eAngle，用来画圆弧

### DIFF
--- a/src/egret/context/renderer/HTML5CanvasRenderer.ts
+++ b/src/egret/context/renderer/HTML5CanvasRenderer.ts
@@ -309,19 +309,18 @@ module egret_h5_graphics {
         this._fill();
     }
 
-    export function drawCircle(x:number, y:number, r:number):void {
+    export function drawCircle(x:number, y:number, r:number, sAngle:number = 0, eAngle:number = Math.PI * 2):void {
 
         this.commandQueue.push(new Command(
-            function (x, y, r) {
+            function (x, y, r, sAngle, eAngle) {
                 var rendererContext = <egret.HTML5CanvasRenderer>this.renderContext;
                 this.canvasContext.beginPath();
                 this.canvasContext.arc(rendererContext._transformTx + x,
-                        rendererContext._transformTy + y, r, 0, Math.PI * 2);
-                this.canvasContext.closePath();
-
+                        rendererContext._transformTy + y, r, sAngle, eAngle);
+                // this.canvasContext.closePath();
             },
             this,
-            [ x, y, r]
+            [ x, y, r, sAngle, eAngle]
         ));
         this._fill();
     }

--- a/src/egret/context/renderer/NativeRendererContext.ts
+++ b/src/egret/context/renderer/NativeRendererContext.ts
@@ -260,7 +260,7 @@ var egret_native_graphics;
 
     egret_native_graphics.drawRect = drawRect;
 
-    function drawCircle(x, y, r) {
+    function drawCircle(x, y, r, sAngle, eAngle) {
 
     }
 

--- a/src/egret/display/Graphics.ts
+++ b/src/egret/display/Graphics.ts
@@ -80,8 +80,10 @@ module egret {
          * @param x {number} 圆心相对于父显示对象注册点的 x 位置（以像素为单位）。
          * @param y {number} 相对于父显示对象注册点的圆心的 y 位置（以像素为单位）。
          * @param r {number} 圆的半径（以像素为单位）。
+         * @param sAngle? {number} 圆的起始弧度（以弧度为单位），默认值为0
+         * @param eAngle? {number} 圆的结束弧度（以弧度为单位），默认值为Math.PI * 2
          */
-        public drawCircle(x:number, y:number, r:number):void {
+        public drawCircle(x:number, y:number, r:number, sAngle:number = 0, eAngle:number = Math.PI * 2):void {
             this.checkRect(x - r, y - r, 2 * r, 2 * r);
         }
 


### PR DESCRIPTION
在开发项目的时候遇到一个需求：绘制圆弧。

HTML5的canvas API里有arcTo这样的实现，而AS3的graphics API并没有，所以Flash开发者往往会用lineTo来模拟绘制圆弧。Egret的API设计直接效仿了AS3的，所以graphics API并不完整，无法直接实现绘制圆弧的需求。

我这边的实现方式是直接扩充了drawCircle函数的参数列表，为其增加两个可选参数。虽然会导致此API的用法与AS3的相关API略有不同，但总体而言是对画圆功能的扩充，不会影响Flash开发者对该API的理解。

潜在的Bug:
如果绘制的时候用beginFill()设置了fillColor，绘制出来的将是圆弧与起始点终点连线闭合起来的一个诡异图形，并且；如果没有fillColor，绘制出来的还会是圆弧。

还可以优化的点：
对于设置了fillColor的情况，理想中绘制出来的图形应该是一个扇形。