### PR TITLE
修正 Linux、FreeBSD 无法正确输出 egret_file_list.js 的 bug

### DIFF
--- a/tools/lib/tools/compile.js
+++ b/tools/lib/tools/compile.js
@@ -501,7 +501,7 @@ function generateAllModuleFileList(projectDir, moduleReferenceList) {
     var all_module_file_list = [];
     all_module.map(function (moduleConfig) {
         moduleConfig.file_list.map(function (item) {
-            var tsFile = file.joinPath(moduleConfig.prefix, moduleConfig.source, item).toLowerCase();
+            var tsFile = file.joinPath(moduleConfig.prefix, moduleConfig.source, item);
             if (item.indexOf(".d.ts") != -1) {
                 return;
             }


### PR DESCRIPTION
经测试，Windows 和 Mac 下这样修改后都不影响。

起因是 Windows 和 Mac 下把路径全小写化之后，fs 模块可以正确访问文件内容。
而在 Linux、FreeBSD 系统下，路径全小写化之后，fs 模块无法读取到文件内容。

而且经检查，这里的小写化本身没有任何必要，所以做了这样的修改。

已经在 Windows、Mac、Linux、FreeBSD 系统都都测试通过，可以正确编译和运行基本 Demo。