### PR TITLE
修正斜切变换算法，优化代码可读性

### DIFF
--- a/src/egret/geom/Matrix.ts
+++ b/src/egret/geom/Matrix.ts
@@ -173,15 +173,14 @@ module egret {
                 this.tx -= regX;
                 this.ty -= regY;
             }
+
             if (skewX || skewY) {
-                // TODO: can this be combined into a single prepend operation?
-//                skewX *= Matrix.DEG_TO_RAD;
-//                skewY *= Matrix.DEG_TO_RAD;
-                this.prepend(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, 0, 0);
-                this.prepend(NumberUtils.cos(skewY), NumberUtils.sin(skewY), -NumberUtils.sin(skewX), NumberUtils.cos(skewX), x, y);
-            } else {
-                this.prepend(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, x, y);
+                var tanX = NumberUtils.sin(skewX) / NumberUtils.cos(skewX);
+                var tanY = NumberUtils.sin(skewY) / NumberUtils.cos(skewY);
+                this.prepend(1, tanY, tanX, 1, 0, 0);
             }
+
+            this.prepend(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, x, y);
             return this;
         }
 
@@ -210,14 +209,12 @@ module egret {
                 sin = 0;
             }
 
+            this.append(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, x, y);
+
             if (skewX || skewY) {
-                // TODO: can this be combined into a single append?
-//                skewX *= Matrix.DEG_TO_RAD;
-//                skewY *= Matrix.DEG_TO_RAD;
-                this.append(NumberUtils.cos(skewY), NumberUtils.sin(skewY), -NumberUtils.sin(skewX), NumberUtils.cos(skewX), x, y);
-                this.append(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, 0, 0);
-            } else {
-                this.append(cos * scaleX, sin * scaleX, -sin * scaleY, cos * scaleY, x, y);
+                var tanX = NumberUtils.sin(skewX) / NumberUtils.cos(skewX);
+                var tanY = NumberUtils.sin(skewY) / NumberUtils.cos(skewY);
+                this.append(1, tanY, tanX, 1, 0, 0);
             }
 
             if (regX || regY) {
@@ -239,16 +236,7 @@ module egret {
             var cos = Math.cos(angle);
             var sin = Math.sin(angle);
 
-            var a1 = this.a;
-            var c1 = this.c;
-            var tx1 = this.tx;
-
-            this.a = a1 * cos - this.b * sin;
-            this.b = a1 * sin + this.b * cos;
-            this.c = c1 * cos - this.d * sin;
-            this.d = c1 * sin + this.d * cos;
-            this.tx = tx1 * cos - this.ty * sin;
-            this.ty = tx1 * sin + this.ty * cos;
+            this.prepend(cos, sin, -sin, cos, 0, 0);
             return this;
         }
 
@@ -261,9 +249,12 @@ module egret {
          * @returns {egret.Matrix}
          */
         public skew(skewX:number, skewY:number):Matrix {
-//            skewX = skewX * Matrix.DEG_TO_RAD;
-//            skewY = skewY * Matrix.DEG_TO_RAD;
-            this.append(NumberUtils.cos(skewY), NumberUtils.sin(skewY), -NumberUtils.sin(skewX), NumberUtils.cos(skewX), 0, 0);
+            // skewX = skewX * Matrix.DEG_TO_RAD;
+            // skewY = skewY * Matrix.DEG_TO_RAD;
+            var tanX = NumberUtils.sin(skewX) / NumberUtils.cos(skewX);
+            var tanY = NumberUtils.sin(skewY) / NumberUtils.cos(skewY);
+
+            this.prepend(1, tanY, tanX, 1, 0, 0);
             return this;
         }
 
@@ -276,12 +267,7 @@ module egret {
          * @returns {egret.Matrix}
          */
         public scale(x:number, y:number):Matrix {
-            this.a *= x;
-            this.d *= y;
-            this.c *= x;
-            this.b *= y;
-            this.tx *= x;
-            this.ty *= y;
+            this.prepend(x, 0, 0, y, 0, 0);
             return this;
         }
 


### PR DESCRIPTION
斜切变换的变换矩阵应是：

```
|    1     tan(x) 0 |
| tan(y)     1    0 |
|    0       0    1 |
```

斜切变换逻辑详见：

http://www.w3.org/TR/SVG/coords.html#EstablishingANewUserSpace