### PR TITLE
修复ScrollView 点击事件中设置scrollLeft/Top无效的bug

### DIFF
--- a/src/egret/display/ScrollView.ts
+++ b/src/egret/display/ScrollView.ts
@@ -388,13 +388,14 @@ module egret {
 
         public _onTouchEnd(event: TouchEvent): void {
             this.touchChildren = true;
+            var scrollStartedOld = this._ScrV_Props_._scrollStarted;
             this._ScrV_Props_._scrollStarted = false;
             egret.MainContext.instance.stage.removeEventListener(TouchEvent.TOUCH_MOVE, this._onTouchMove, this);
             egret.MainContext.instance.stage.removeEventListener(TouchEvent.TOUCH_END, this._onTouchEnd, this);
             egret.MainContext.instance.stage.removeEventListener(TouchEvent.LEAVE_STAGE, this._onTouchEnd, this);
             this.removeEventListener(Event.ENTER_FRAME, this._onEnterFrame, this);
             
-            this._moveAfterTouchEnd();
+            scrollStartedOld && this._moveAfterTouchEnd();
         }
 
 


### PR DESCRIPTION
点击时有小概率触发 tween scrollLeft/Top,duration=1
比如我在 ScrollView 里有个按钮需要点击后改变scrollLeft=100,这个 bug 会导致1毫秒之后 scrollLeft 又回到之前的初始值0,相当于设置失效