### PR TITLE
修正EgretSlot.ts的dispose方法未判断displayList为null的bug

### DIFF
--- a/src/extension/dragonbones/egret/EgretSlot.ts
+++ b/src/extension/dragonbones/egret/EgretSlot.ts
@@ -51,11 +51,14 @@ module dragonBones {
          * 释放资源
          */
         public dispose():void{
-            var length:number = this._displayList.length;
-            for(var i:number = 0;i < length;i++){
-                var content:any = this._displayList[i];
-                if(content instanceof Armature){
-                    (<Armature><any> content).dispose();
+            if(this._displayList != null)
+            {
+                var length:number = this._displayList.length;
+                for(var i:number = 0;i < length;i++){
+                    var content:any = this._displayList[i];
+                    if(content instanceof Armature){
+                        (<Armature><any> content).dispose();
+                    }
                 }
             }
             super.dispose();


### PR DESCRIPTION
在armature.dispose中_displayList会被删除为null，所以这里需要先检查是否已为null