### PR TITLE
计时器在运行到了重复次数时会继续运行

### DIFF
--- a/src/egret/utils/Timer.ts
+++ b/src/egret/utils/Timer.ts
@@ -202,6 +202,8 @@ module egret {
         public start() {
             if(this._running)
                 return;
+            if(this.repeatCount!=0&&this._currentCount==this.repeatCount)
+                return;
             sys.$ticker.$startTick(this.$update,this);
             this._running = true;
         }


### PR DESCRIPTION
计时器在运行到了重复次数时调用stop()再调用start()又会执行一次，可能要重写sys.$ticker，但是我不知道这是指向哪里。。。。还望指点