### PR TITLE
fix error when input chinese

### DIFF
--- a/src/egret/text/web/HTML5StageText.ts
+++ b/src/egret/text/web/HTML5StageText.ts
@@ -280,10 +280,14 @@ module egret.web {
                 }
                 else {
                     window.setTimeout(function () {
-                        if (self.inputElement.selectionStart == self.inputElement.selectionEnd) {
-                            self.textValue = self.inputElement.value;
+                        if(self.inputElement) {
+                            if(self.inputElement.selectionStart && self.inputElement.selectionEnd) {
+                                if (self.inputElement.selectionStart == self.inputElement.selectionEnd) {
+                                    self.textValue = self.inputElement.value;
 
-                            egret.Event.dispatchEvent(self, "updateText", false);
+                                    egret.Event.dispatchEvent(self, "updateText", false);
+                                }                                
+                            }
                         }
                     }, 0);
                 }


### PR DESCRIPTION
文本框输入文本输入中文的时候，如果在选择文字的状态下文本框失去焦点，inputElement为空，报错