### PR TITLE
fix scroller bug

### DIFF
--- a/src/extension/eui/components/Scroller.ts
+++ b/src/extension/eui/components/Scroller.ts
@@ -640,10 +640,10 @@ module eui {
                 if(!outX && !outY){
                     return;
                 }
-                if(outX && values[Keys.scrollPolicyH] == 'off'){
+                if(!outY && outX && values[Keys.scrollPolicyH] == 'off'){
                     return;
                 }
-                if(outY && values[Keys.scrollPolicyV] == 'off') {
+                if(!outX && outY && values[Keys.scrollPolicyV] == 'off') {
                     return;
                 }
 


### PR DESCRIPTION
当Scroller的scrollPolicyH设置为off，在Scroller做对角线方向滑动时会因为outX为true且判断scrollPolicyH为off而滑动逻辑终止导致滑动不流畅。当Scroller的scrollPolicyV设置为off时亦同。