### PR TITLE
fix DataGroup.getVirtualElementAt bug

### DIFF
--- a/src/extension/eui/components/DataGroup.ts
+++ b/src/extension/eui/components/DataGroup.ts
@@ -300,6 +300,7 @@ module eui {
             if (freeRenderers[hashCode] && freeRenderers[hashCode].length > 0) {
                 renderer = freeRenderers[hashCode].pop();
                 renderer.visible = true;
+                this.invalidateDisplayList();
                 return renderer;
             }
             values[Keys.createNewRendererFlag] = true;


### PR DESCRIPTION
List开启虚拟布局 在两次以上调用getVirtualElementAt获取不在显示区域内的列表项 会出现列表异常
第一次调用会创建新的列表项返回外部 因为调用了list的addChild导致列表会进行更新 所以显示正常
第二次调用会返回缓存池内的列表项 没有触发列表的进行更新 所以出现了列表异常情况 所以取缓存次内的列表项 且 设置了列表项的visible属性时应当触发列表的更新操作 

![bug](https://cloud.githubusercontent.com/assets/19904732/16553536/c7c3ea5a-41fb-11e6-9d70-95a7b99a8b00.png)
