### PR TITLE
Bug fix: Modify getIOSVersion function for iOS 10.

### DIFF
--- a/src/egret/web/Html5Capatibility.ts
+++ b/src/egret/web/Html5Capatibility.ts
@@ -198,7 +198,7 @@ module egret.web {
          */
         private static getIOSVersion():number {
             var value = Html5Capatibility.ua.toLowerCase().match(/cpu [^\d]*\d.*like mac os x/)[0];
-            return parseInt(value.match(/\d(_\d)*/)[0]) || 0;
+            return parseInt(value.match(/\d+(_\d)*/)[0]) || 0;
         }
 
         /**


### PR DESCRIPTION
原函数 getIOSVersion 只能对应iOS 的版本号是1位数的情况。
当iOS version升级到10时，getIOSVersion的返回值是1。