### PR TITLE
白鹭没有提供方法用于兼听文本框的其他事件，比如"keydown","keyup"等

### DIFF
--- a/src/egret/text/web/HTML5StageText.ts
+++ b/src/egret/text/web/HTML5StageText.ts
@@ -175,13 +175,13 @@ namespace egret.web {
          * @private
          * 
          */
-        private onBlurHandler(): void {
-            this.htmlInput.clearInputElement();
-            window.scrollTo(0, 0);
+        private onBlurHandler(): void {            
             let elem = <HTMLInputElement>this.inputElement;
             HTML5StageText.rawEvents.forEach(type => {
                 elem.removeEventListener(type, this.evHandler);
             });
+            this.htmlInput.clearInputElement();
+            window.scrollTo(0, 0);
         }
 
         /**

--- a/src/egret/text/web/HTML5StageText.ts
+++ b/src/egret/text/web/HTML5StageText.ts
@@ -165,15 +165,32 @@ namespace egret.web {
             this._isNeedShow = true;
 
             this._initElement();
+            let elem = <HTMLInputElement>this.inputElement;
+            HTML5StageText.rawEvents.forEach(type => {
+                elem.addEventListener(type, this.evHandler);
+            });
         }
 
         /**
          * @private
          * 
          */
-        private onBlurHandler():void {
+        private onBlurHandler(): void {
             this.htmlInput.clearInputElement();
             window.scrollTo(0, 0);
+            let elem = <HTMLInputElement>this.inputElement;
+            HTML5StageText.rawEvents.forEach(type => {
+                elem.removeEventListener(type, this.evHandler);
+            });
+        }
+
+        /**
+        * 用于兼听文本框的原始事件
+        **/
+        public static rawEvents = [];//可在项目中重写此值，如 ["keyup", "keydown", "keypress"];
+
+        private evHandler = ev => {
+            this.$textfield.dispatchEventWith(ev.type, ev.bubbles, ev, ev.cancelable);
         }
 
         /**


### PR DESCRIPTION
增加一个static的rawEvents，方便项目中加入关注的事件监听。
同时不用暴露 inputElement