### PR TITLE
优化ByteArray，解决用ByteArray做大量写入操作时，效率过低的问题

### DIFF
--- a/src/egret/utils/ByteArray.ts
+++ b/src/egret/utils/ByteArray.ts
@@ -157,14 +157,11 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        protected _endian: string;
-
         public get endian() {
-            return this._endian;
+            return this.$endian == EndianConst.LITTLE_ENDIAN ? Endian.LITTLE_ENDIAN : Endian.BIG_ENDIAN;
         }
 
         public set endian(value: string) {
-            this._endian = value;
             this.$endian = value == Endian.LITTLE_ENDIAN ? EndianConst.LITTLE_ENDIAN : EndianConst.BIG_ENDIAN;
         }
 

--- a/src/egret/utils/ByteArray.ts
+++ b/src/egret/utils/ByteArray.ts
@@ -718,7 +718,7 @@ namespace egret {
             }
             if (writeLength > 0) {
                 this.validateBuffer(writeLength);
-                this._bytes.set(bytes._bytes.slice(offset, offset + writeLength), this._position);
+                this._bytes.set(bytes._bytes.subarray(offset, offset + writeLength), this._position);
                 this.position = this._position + writeLength;
             }
         }

--- a/src/egret/utils/ByteArray.ts
+++ b/src/egret/utils/ByteArray.ts
@@ -1073,7 +1073,7 @@ namespace egret {
         }
     }
     let pt = ByteArray.prototype;
-    if (TextDecoder) {//如果有原生的文本编码解析类  浏览器支持状况： http://caniuse.com/#feat=textencoder
+    if (typeof TextDecoder === "function") {//如果有原生的文本编码解析类  浏览器支持状况： http://caniuse.com/#feat=textencoder
         let td = new TextDecoder();
         pt.decodeUTF8 = td.decode.bind(td);
         let te = new TextEncoder();

--- a/src/egret/utils/ByteArray.ts
+++ b/src/egret/utils/ByteArray.ts
@@ -58,7 +58,7 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public static LITTLE_ENDIAN:string = "littleEndian";
+        public static LITTLE_ENDIAN: string = "littleEndian";
 
         /**
          * Indicates the most significant byte of the multibyte number appears first in the sequence of bytes.
@@ -74,10 +74,35 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public static BIG_ENDIAN:string = "bigEndian";
+        public static BIG_ENDIAN: string = "bigEndian";
 
     }
 
+    export const enum EndianConst {
+        LITTLE_ENDIAN = 0,
+        BIG_ENDIAN = 1
+    }
+
+    const enum ByteArraySize {
+
+        SIZE_OF_BOOLEAN = 1,
+
+        SIZE_OF_INT8 = 1,
+
+        SIZE_OF_INT16 = 2,
+
+        SIZE_OF_INT32 = 4,
+
+        SIZE_OF_UINT8 = 1,
+
+        SIZE_OF_UINT16 = 2,
+
+        SIZE_OF_UINT32 = 4,
+
+        SIZE_OF_FLOAT32 = 4,
+
+        SIZE_OF_FLOAT64 = 8
+    }
     /**
      * The ByteArray class provides methods and attributes for optimized reading and writing as well as dealing with binary data.
      * Note: The ByteArray class is applied to the advanced developers who need to access data at the byte layer.
@@ -95,111 +120,134 @@ namespace egret {
      * @language zh_CN
      */
     export class ByteArray {
-        /**
-         * @private
-         */
-        private static SIZE_OF_BOOLEAN:number = 1;
-        /**
-         * @private
-         */
-        private static SIZE_OF_INT8:number = 1;
-        /**
-         * @private
-         */
-        private static SIZE_OF_INT16:number = 2;
-        /**
-         * @private
-         */
-        private static SIZE_OF_INT32:number = 4;
-        /**
-         * @private
-         */
-        private static SIZE_OF_UINT8:number = 1;
-        /**
-         * @private
-         */
-        private static SIZE_OF_UINT16:number = 2;
-        /**
-         * @private
-         */
-        private static SIZE_OF_UINT32:number = 4;
-        /**
-         * @private
-         */
-        private static SIZE_OF_FLOAT32:number = 4;
-        /**
-         * @private
-         */
-        private static SIZE_OF_FLOAT64:number = 8;
 
         /**
          * @private
          */
-        private BUFFER_EXT_SIZE:number = 0;//Buffer expansion size
+        protected bufferExtSize = 256;//Buffer expansion size
 
-        private data:DataView;
+        protected data: DataView;
+
+        protected _bytes: Uint8Array;
         /**
          * @private
          */
-        private _position:number;
-        /**
-         * @private
-         */
-        private write_position:number;
+        protected _position: number;
 
         /**
-         * Changes or reads the byte order; egret.Endian.BIG_ENDIAN or egret.Endian.LITTLE_ENDIAN.
-         * @default egret.Endian.BIG_ENDIAN
+         * 
+         * 已经使用的字节偏移量
+         * @protected
+         * @type {number}
+         * @memberOf ByteArray
+         */
+        protected write_position: number;
+
+        /**
+         * Changes or reads the byte order; egret.EndianConst.BIG_ENDIAN or egret.EndianConst.LITTLE_EndianConst.
+         * @default egret.EndianConst.BIG_ENDIAN
          * @version Egret 2.4
          * @platform Web,Native
          * @language en_US
          */
         /**
-         * 更改或读取数据的字节顺序；egret.Endian.BIG_ENDIAN 或 egret.Endian.LITTLE_ENDIAN。
-         * @default egret.Endian.BIG_ENDIAN
+         * 更改或读取数据的字节顺序；egret.EndianConst.BIG_ENDIAN 或 egret.EndianConst.LITTLE_ENDIAN。
+         * @default egret.EndianConst.BIG_ENDIAN
          * @version Egret 2.4
          * @platform Web,Native
          * @language zh_CN
          */
-        public endian:string;
+        protected _endian: string;
+
+        public get endian() {
+            return this._endian;
+        }
+
+        public set endian(value: string) {
+            this._endian = value;
+            this.$endian = value == Endian.LITTLE_ENDIAN ? EndianConst.LITTLE_ENDIAN : EndianConst.BIG_ENDIAN;
+        }
+
+        protected $endian: EndianConst;
 
         /**
          * @version Egret 2.4
          * @platform Web,Native
          */
-        constructor(buffer?:ArrayBuffer) {
-            this._setArrayBuffer(buffer || new ArrayBuffer(this.BUFFER_EXT_SIZE));
+        constructor(buffer?: ArrayBuffer | Uint8Array, bufferExtSize = 256) {
+            if (bufferExtSize < 0) {
+                bufferExtSize = 256;
+            }
+            this.bufferExtSize = bufferExtSize;
+            let bytes: Uint8Array, wpos = 0;
+            if (buffer) {//有数据，则可写字节数从字节尾开始
+                let uint8: Uint8Array, wpos: number;
+                if (buffer instanceof Uint8Array) {
+                    uint8 = buffer;
+                    wpos = buffer.length;
+                } else {
+                    wpos = buffer.byteLength;
+                    uint8 = new Uint8Array(buffer);
+                }
+                let multi = (wpos / bufferExtSize | 0) + 1;
+                bytes = new Uint8Array(multi * bufferExtSize);
+                bytes.set(uint8);
+            } else {
+                bytes = new Uint8Array(bufferExtSize);
+            }
+            this.write_position = wpos;
+            this._position = 0;
+            this._bytes = bytes;
+            this.data = new DataView(bytes.buffer);
             this.endian = Endian.BIG_ENDIAN;
         }
 
-        /**
-         * @private
-         * @param buffer
-         */
-        private _setArrayBuffer(buffer:ArrayBuffer):void {
-            this.write_position = buffer.byteLength;
-            this.data = new DataView(buffer);
-            this._position = 0;
-        }
 
         /**
          * @deprecated
          * @version Egret 2.4
          * @platform Web,Native
          */
-        public setArrayBuffer(buffer:ArrayBuffer):void {
+        public setArrayBuffer(buffer: ArrayBuffer): void {
 
         }
 
-        public get buffer():ArrayBuffer {
+        /**
+         * 可读的剩余字节数
+         * 
+         * @returns 
+         * 
+         * @memberOf ByteArray
+         */
+        public get readAvailable() {
+            return this.write_position - this._position;
+        }
+
+        public get buffer(): ArrayBuffer {
+            return this.data.buffer.slice(0, this.write_position);
+        }
+
+        public get rawBuffer(): ArrayBuffer {
             return this.data.buffer;
         }
 
         /**
          * @private
          */
-        public set buffer(value:ArrayBuffer) {
-            this.data = new DataView(value);
+        public set buffer(value: ArrayBuffer) {
+            let wpos = value.byteLength;
+            let uint8 = new Uint8Array(value);
+            let bufferExtSize = this.bufferExtSize;
+            let multi = (wpos / bufferExtSize | 0) + 1;
+            let bytes = new Uint8Array(multi * bufferExtSize);
+            bytes.set(uint8);
+            this.write_position = wpos;
+            this._bytes = bytes;
+            this.data = new DataView(bytes.buffer);
+        }
+
+        public get bytes(): Uint8Array {
+            return this._bytes;
         }
 
         /**
@@ -207,22 +255,21 @@ namespace egret {
          * @version Egret 2.4
          * @platform Web,Native
          */
-        public get dataView():DataView {
+        public get dataView(): DataView {
             return this.data;
         }
 
         /**
          * @private
          */
-        public set dataView(value:DataView) {
-            this.data = value;
-            this.write_position = value.byteLength;
+        public set dataView(value: DataView) {
+            this.buffer = value.buffer;
         }
 
         /**
          * @private
          */
-        public get bufferOffset():number {
+        public get bufferOffset(): number {
             return this.data.byteOffset;
         }
 
@@ -238,18 +285,15 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public get position():number {
+        public get position(): number {
             return this._position;
         }
 
-        public set position(value:number) {
-            //if (this._position < value) {
-            //    if (!this.validate(value - this._position)) {
-            //        return;
-            //    }
-            //}
+        public set position(value: number) {
             this._position = value;
-            this.write_position = value > this.write_position ? value : this.write_position;
+            if (value > this.write_position) {
+                this.write_position = value;
+            }
         }
 
         /**
@@ -268,20 +312,27 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public get length():number {
+        public get length(): number {
             return this.write_position;
         }
 
-        public set length(value:number) {
+        public set length(value: number) {
             this.write_position = value;
-            let tmp:Uint8Array = new Uint8Array(new ArrayBuffer(value));
-            let byteLength:number = this.data.buffer.byteLength;
-            if (byteLength > value) {
+            if (this.data.byteLength > value) {
                 this._position = value;
             }
-            let length:number = Math.min(byteLength, value);
-            tmp.set(new Uint8Array(this.data.buffer, 0, length));
-            this.buffer = tmp.buffer;
+            this._validateBuffer(value);
+        }
+
+        protected _validateBuffer(value: number) {
+            if (this.data.byteLength < value) {
+                let be = this.bufferExtSize;
+                let nLen = ((value / be >> 0) + 1) * be;
+                let tmp: Uint8Array = new Uint8Array(nLen);
+                tmp.set(this._bytes);
+                this._bytes = tmp;
+                this.data = new DataView(tmp.buffer);
+            }
         }
 
         /**
@@ -298,7 +349,7 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public get bytesAvailable():number {
+        public get bytesAvailable(): number {
             return this.data.byteLength - this._position;
         }
 
@@ -309,13 +360,17 @@ namespace egret {
          * @language en_US
          */
         /**
-         * 清除字节数组的内容，并将 length 和 position 属性重置为 0。 
+         * 清除字节数组的内容，并将 length 和 position 属性重置为 0。
          * @version Egret 2.4
          * @platform Web,Native
          * @language zh_CN
          */
-        public clear():void {
-            this._setArrayBuffer(new ArrayBuffer(this.BUFFER_EXT_SIZE));
+        public clear(): void {
+            let buffer = this.data.buffer.slice(0, this.bufferExtSize);
+            this.data = new DataView(buffer);
+            this._bytes = new Uint8Array(buffer);
+            this._position = 0;
+            this.write_position = 0;
         }
 
         /**
@@ -332,10 +387,8 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readBoolean():boolean {
-            if (!this.validate(ByteArray.SIZE_OF_BOOLEAN)) return null;
-
-            return this.data.getUint8(this.position++) != 0;
+        public readBoolean(): boolean {
+            if (this.validate(ByteArraySize.SIZE_OF_BOOLEAN)) return !!this._bytes[this.position++];
         }
 
         /**
@@ -352,10 +405,8 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readByte():number {
-            if (!this.validate(ByteArray.SIZE_OF_INT8)) return null;
-
-            return this.data.getInt8(this.position++);
+        public readByte(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_INT8)) return this.data.getInt8(this.position++);
         }
 
         /**
@@ -376,12 +427,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readBytes(bytes:ByteArray, offset:number = 0, length:number = 0):void {
+        public readBytes(bytes: ByteArray, offset: number = 0, length: number = 0): void {
             if (length == 0) {
                 length = this.bytesAvailable;
             }
             else if (!this.validate(length)) {
-                return null;
+                return;
             }
             if (bytes) {
                 bytes.validateBuffer(offset + length);
@@ -409,12 +460,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readDouble():number {
-            if (!this.validate(ByteArray.SIZE_OF_FLOAT64)) return null;
-
-            let value:number = this.data.getFloat64(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_FLOAT64;
-            return value;
+        public readDouble(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_FLOAT64)) {
+                let value = this.data.getFloat64(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_FLOAT64;
+                return value;
+            }
         }
 
         /**
@@ -431,12 +482,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readFloat():number {
-            if (!this.validate(ByteArray.SIZE_OF_FLOAT32)) return null;
-
-            let value:number = this.data.getFloat32(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_FLOAT32;
-            return value;
+        public readFloat(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_FLOAT32)) {
+                let value = this.data.getFloat32(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_FLOAT32;
+                return value;
+            }
         }
 
         /**
@@ -453,26 +504,13 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readInt():number {
-            if (!this.validate(ByteArray.SIZE_OF_INT32)) return null;
-
-            let value = this.data.getInt32(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_INT32;
-            return value;
+        public readInt(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_INT32)) {
+                let value = this.data.getInt32(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_INT32;
+                return value;
+            }
         }
-
-        ///**
-        // * 使用指定的字符集从字节流中读取指定长度的多字节字符串
-        // * @param length 要从字节流中读取的字节数
-        // * @param charSet 表示用于解释字节的字符集的字符串。可能的字符集字符串包括 "shift-jis"、"cn-gb"、"iso-8859-1"”等
-        // * @return UTF-8 编码的字符串
-        // * @method egret.ByteArray#readMultiByte
-        // */
-        //public readMultiByte(length:number, charSet?:string):string {
-        //    if (!this.validate(length)) return null;
-        //
-        //    return "";
-        //}
 
         /**
          * Read a 16-bit signed integer from the byte stream.
@@ -488,12 +526,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readShort():number {
-            if (!this.validate(ByteArray.SIZE_OF_INT16)) return null;
-
-            let value = this.data.getInt16(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_INT16;
-            return value;
+        public readShort(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_INT16)) {
+                let value = this.data.getInt16(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_INT16;
+                return value;
+            }
         }
 
         /**
@@ -510,10 +548,8 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readUnsignedByte():number {
-            if (!this.validate(ByteArray.SIZE_OF_UINT8)) return null;
-
-            return this.data.getUint8(this.position++);
+        public readUnsignedByte(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_UINT8)) return this._bytes[this.position++];
         }
 
         /**
@@ -530,12 +566,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readUnsignedInt():number {
-            if (!this.validate(ByteArray.SIZE_OF_UINT32)) return null;
-
-            let value = this.data.getUint32(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT32;
-            return value;
+        public readUnsignedInt(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_UINT32)) {
+                let value = this.data.getUint32(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_UINT32;
+                return value;
+            }
         }
 
         /**
@@ -552,12 +588,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readUnsignedShort():number {
-            if (!this.validate(ByteArray.SIZE_OF_UINT16)) return null;
-
-            let value = this.data.getUint16(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT16;
-            return value;
+        public readUnsignedShort(): number {
+            if (this.validate(ByteArraySize.SIZE_OF_UINT16)) {
+                let value = this.data.getUint16(this._position, this.$endian == EndianConst.LITTLE_ENDIAN);
+                this.position += ByteArraySize.SIZE_OF_UINT16;
+                return value;
+            }
         }
 
         /**
@@ -574,12 +610,8 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readUTF():string {
-            if (!this.validate(ByteArray.SIZE_OF_UINT16)) return null;
-
-            let length:number = this.data.getUint16(this.position, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT16;
-
+        public readUTF(): string {
+            let length = this.readUnsignedShort();
             if (length > 0) {
                 return this.readUTFBytes(length);
             } else {
@@ -603,15 +635,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public readUTFBytes(length:number):string {
-            if (!this.validate(length)) return null;
-
-            let bytes:Uint8Array = new Uint8Array(this.buffer, this.bufferOffset + this.position, length);
+        public readUTFBytes(length: number): string {
+            if (!this.validate(length)) return;
+            let bytes = new Uint8Array(this.buffer, this.bufferOffset + this._position, length);
             this.position += length;
-            /*let bytes: Uint8Array = new Uint8Array(new ArrayBuffer(length));
-             for (let i = 0; i < length; i++) {
-             bytes[i] = this.data.getUint8(this.position++);
-             }*/
             return this.decodeUTF8(bytes);
         }
 
@@ -629,10 +656,9 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeBoolean(value:boolean):void {
-            this.validateBuffer(ByteArray.SIZE_OF_BOOLEAN);
-
-            this.data.setUint8(this.position++, value ? 1 : 0);
+        public writeBoolean(value: boolean): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_BOOLEAN);
+            this._bytes[this.position++] = +value;
         }
 
         /**
@@ -651,10 +677,9 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeByte(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_INT8);
-
-            this.data.setInt8(this.position++, value);
+        public writeByte(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_INT8);
+            this._bytes[this.position++] = value & 0xff;
         }
 
         /**
@@ -679,34 +704,22 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeBytes(bytes:ByteArray, offset:number = 0, length:number = 0):void {
-            let writeLength:number;
+        public writeBytes(bytes: ByteArray, offset: number = 0, length: number = 0): void {
+            let writeLength: number;
             if (offset < 0) {
                 return;
             }
             if (length < 0) {
                 return;
-            }
-            else if (length == 0) {
+            } else if (length == 0) {
                 writeLength = bytes.length - offset;
-            }
-            else {
+            } else {
                 writeLength = Math.min(bytes.length - offset, length);
             }
             if (writeLength > 0) {
                 this.validateBuffer(writeLength);
-
-                let tmp_data = new DataView(bytes.buffer);
-                let length = writeLength;
-                let BYTES_OF_UINT32 = 4;
-                for (; length > BYTES_OF_UINT32; length -= BYTES_OF_UINT32) {
-                    this.data.setUint32(this._position, tmp_data.getUint32(offset));
-                    this.position += BYTES_OF_UINT32;
-                    offset += BYTES_OF_UINT32;
-                }
-                for (; length > 0; length--) {
-                    this.data.setUint8(this.position++, tmp_data.getUint8(offset++));
-                }
+                this._bytes.set(bytes._bytes.slice(offset, offset + writeLength), this._position);
+                this.position = this._position + writeLength;
             }
         }
 
@@ -724,11 +737,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeDouble(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_FLOAT64);
-
-            this.data.setFloat64(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_FLOAT64;
+        public writeDouble(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_FLOAT64);
+            this.data.setFloat64(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_FLOAT64;
         }
 
         /**
@@ -745,11 +757,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeFloat(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_FLOAT32);
-
-            this.data.setFloat32(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_FLOAT32;
+        public writeFloat(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_FLOAT32);
+            this.data.setFloat32(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_FLOAT32;
         }
 
         /**
@@ -766,11 +777,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeInt(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_INT32);
-
-            this.data.setInt32(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_INT32;
+        public writeInt(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_INT32);
+            this.data.setInt32(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_INT32;
         }
 
         /**
@@ -787,11 +797,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeShort(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_INT16);
-
-            this.data.setInt16(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_INT16;
+        public writeShort(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_INT16);
+            this.data.setInt16(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_INT16;
         }
 
         /**
@@ -808,11 +817,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeUnsignedInt(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_UINT32);
-
-            this.data.setUint32(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT32;
+        public writeUnsignedInt(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_UINT32);
+            this.data.setUint32(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_UINT32;
         }
 
         /**
@@ -829,11 +837,10 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeUnsignedShort(value:number):void {
-            this.validateBuffer(ByteArray.SIZE_OF_UINT16);
-
-            this.data.setUint16(this.position, value, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT16;
+        public writeUnsignedShort(value: number): void {
+            this.validateBuffer(ByteArraySize.SIZE_OF_UINT16);
+            this.data.setUint16(this._position, value, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_UINT16;
         }
 
         /**
@@ -850,14 +857,12 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeUTF(value:string):void {
-            let utf8bytes:Uint8Array = this.encodeUTF8(value);
-            let length:number = utf8bytes.length;
-
-            this.validateBuffer(ByteArray.SIZE_OF_UINT16 + length);
-
-            this.data.setUint16(this.position, length, this.endian == Endian.LITTLE_ENDIAN);
-            this.position += ByteArray.SIZE_OF_UINT16;
+        public writeUTF(value: string): void {
+            let utf8bytes: ArrayLike<number> = this.encodeUTF8(value);
+            let length: number = utf8bytes.length;
+            this.validateBuffer(ByteArraySize.SIZE_OF_UINT16 + length);
+            this.data.setUint16(this._position, length, this.$endian == EndianConst.LITTLE_ENDIAN);
+            this.position += ByteArraySize.SIZE_OF_UINT16;
             this._writeUint8Array(utf8bytes, false);
         }
 
@@ -875,7 +880,7 @@ namespace egret {
          * @platform Web,Native
          * @language zh_CN
          */
-        public writeUTFBytes(value:string):void {
+        public writeUTFBytes(value: string): void {
             this._writeUint8Array(this.encodeUTF8(value));
         }
 
@@ -886,7 +891,7 @@ namespace egret {
          * @version Egret 2.4
          * @platform Web,Native
          */
-        public toString():string {
+        public toString(): string {
             return "[ByteArray] length:" + this.length + ", bytesAvailable:" + this.bytesAvailable;
         }
 
@@ -896,14 +901,14 @@ namespace egret {
          * @param bytes 要写入的Uint8Array
          * @param validateBuffer
          */
-        public _writeUint8Array(bytes:Uint8Array, validateBuffer:boolean = true):void {
+        public _writeUint8Array(bytes: Uint8Array | ArrayLike<number>, validateBuffer: boolean = true): void {
+            let pos = this._position;
+            let npos = pos + bytes.length;
             if (validateBuffer) {
-                this.validateBuffer(this.position + bytes.length);
+                this.validateBuffer(npos);
             }
-
-            for (let i = 0; i < bytes.length; i++) {
-                this.data.setUint8(this.position++, bytes[i]);
-            }
+            this.bytes.set(bytes, pos);
+            this.position = npos;
         }
 
         /**
@@ -913,9 +918,9 @@ namespace egret {
          * @platform Web,Native
          * @private
          */
-        public validate(len:number):boolean {
-            //len += this.data.byteOffset;
-            if (this.data.byteLength > 0 && this._position + len <= this.data.byteLength) {
+        public validate(len: number): boolean {
+            let bl = this._bytes.length;
+            if (bl > 0 && this._position + len <= bl) {
                 return true;
             } else {
                 egret.$error(1025);
@@ -930,241 +935,162 @@ namespace egret {
          * @param len
          * @param needReplace
          */
-        private validateBuffer(len:number, needReplace:boolean = false):void {
+        protected validateBuffer(len: number): void {
             this.write_position = len > this.write_position ? len : this.write_position;
             len += this._position;
-            if (this.data.byteLength < len || needReplace) {
-                let tmp:Uint8Array = new Uint8Array(new ArrayBuffer(len + this.BUFFER_EXT_SIZE));
-                let length = Math.min(this.data.buffer.byteLength, len + this.BUFFER_EXT_SIZE);
-                tmp.set(new Uint8Array(this.data.buffer, 0, length));
-                this.buffer = tmp.buffer;
+            this._validateBuffer(len);
+        }
+
+        // /**
+        //  * @private
+        //  *
+        //  * @param code_point
+        //  */
+        // private encoderError(code_point) {
+        //     egret.$error(1026, code_point);
+        // }
+
+        // /**
+        //  * @private
+        //  *
+        //  * @param fatal
+        //  * @param opt_code_point
+        //  * @returns
+        //  */
+        // private decoderError(fatal, opt_code_point?): number {
+        //     if (fatal) {
+        //         egret.$error(1027);
+        //     }
+        //     return opt_code_point || 0xFFFD;
+        // }
+
+        /**
+         * 获取字符串使用Utf8编码的字节长度
+         * 
+         * 参考 https://github.com/dcodeIO/protobuf.js/tree/master/lib/utf8
+         * @static
+         * @param {string} string 
+         * @returns 
+         * 
+         * @memberOf ByteArray
+         */
+        public static utf8ByteLength(string: string) {
+            let len = 0,
+                c = 0;
+            for (let i = 0; i < string.length; ++i) {
+                c = string.charCodeAt(i);
+                if (c < 128)
+                    len += 1;
+                else if (c < 2048)
+                    len += 2;
+                else if ((c & 0xFC00) === 0xD800 && (string.charCodeAt(i + 1) & 0xFC00) === 0xDC00) {
+                    ++i;
+                    len += 4;
+                } else
+                    len += 3;
             }
+            return len;
         }
 
         /**
-         * @private
-         * UTF-8 Encoding/Decoding
+         * 接续utf8字符串
+         * 
+         * 参考 https://github.com/dcodeIO/protobuf.js/tree/master/lib/utf8
+         * @param {string} string 
+         * @returns 
+         * @protected
+         * @memberOf ByteArray
          */
-        private encodeUTF8(str:string):Uint8Array {
-            let pos:number = 0;
-            let codePoints = this.stringToCodePoints(str);
-            let outputBytes = [];
-
-            while (codePoints.length > pos) {
-                let code_point:number = codePoints[pos++];
-
-                if (this.inRange(code_point, 0xD800, 0xDFFF)) {
-                    this.encoderError(code_point);
-                }
-                else if (this.inRange(code_point, 0x0000, 0x007f)) {
-                    outputBytes.push(code_point);
+        encodeUTF8(string: string) {
+            let offset = 0,
+                c1: number, // character 1
+                c2: number; // character 2
+            let buffer: number[] = [];//new Uint8Array(ByteArray.utf8ByteLength(string));
+            for (var i = 0; i < string.length; ++i) {
+                c1 = string.charCodeAt(i);
+                if (c1 < 128) {
+                    buffer[offset++] = c1;
+                } else if (c1 < 2048) {
+                    buffer[offset++] = c1 >> 6 | 192;
+                    buffer[offset++] = c1 & 63 | 128;
+                } else if ((c1 & 0xFC00) === 0xD800 && ((c2 = string.charCodeAt(i + 1)) & 0xFC00) === 0xDC00) {
+                    c1 = 0x10000 + ((c1 & 0x03FF) << 10) + (c2 & 0x03FF);
+                    ++i;
+                    buffer[offset++] = c1 >> 18 | 240;
+                    buffer[offset++] = c1 >> 12 & 63 | 128;
+                    buffer[offset++] = c1 >> 6 & 63 | 128;
+                    buffer[offset++] = c1 & 63 | 128;
                 } else {
-                    let count, offset;
-                    if (this.inRange(code_point, 0x0080, 0x07FF)) {
-                        count = 1;
-                        offset = 0xC0;
-                    } else if (this.inRange(code_point, 0x0800, 0xFFFF)) {
-                        count = 2;
-                        offset = 0xE0;
-                    } else if (this.inRange(code_point, 0x10000, 0x10FFFF)) {
-                        count = 3;
-                        offset = 0xF0;
-                    }
-
-                    outputBytes.push(this.div(code_point, Math.pow(64, count)) + offset);
-
-                    while (count > 0) {
-                        let temp = this.div(code_point, Math.pow(64, count - 1));
-                        outputBytes.push(0x80 + (temp % 64));
-                        count -= 1;
-                    }
+                    buffer[offset++] = c1 >> 12 | 224;
+                    buffer[offset++] = c1 >> 6 & 63 | 128;
+                    buffer[offset++] = c1 & 63 | 128;
                 }
             }
-            return new Uint8Array(outputBytes);
+            return buffer;
         }
 
         /**
-         * @private
-         *
-         * @param data
-         * @returns
+         * 从字节数组中读取utf8字符串
+         * 
+         * 参考 https://github.com/dcodeIO/protobuf.js/tree/master/lib/utf8
+         * @param {(Uint8Array | ArrayLike<number>)} buffer 
+         * @returns 
+         * 
+         * @memberOf ByteArray
          */
-        private decodeUTF8(data:Uint8Array):string {
-            let fatal:boolean = false;
-            let pos:number = 0;
-            let result:string = "";
-            let code_point:number;
-            let utf8_code_point = 0;
-            let utf8_bytes_needed = 0;
-            let utf8_bytes_seen = 0;
-            let utf8_lower_boundary = 0;
-
-            while (data.length > pos) {
-
-                let _byte = data[pos++];
-
-                if (_byte == this.EOF_byte) {
-                    if (utf8_bytes_needed != 0) {
-                        code_point = this.decoderError(fatal);
-                    } else {
-                        code_point = this.EOF_code_point;
-                    }
-                } else {
-
-                    if (utf8_bytes_needed == 0) {
-                        if (this.inRange(_byte, 0x00, 0x7F)) {
-                            code_point = _byte;
-                        } else {
-                            if (this.inRange(_byte, 0xC2, 0xDF)) {
-                                utf8_bytes_needed = 1;
-                                utf8_lower_boundary = 0x80;
-                                utf8_code_point = _byte - 0xC0;
-                            } else if (this.inRange(_byte, 0xE0, 0xEF)) {
-                                utf8_bytes_needed = 2;
-                                utf8_lower_boundary = 0x800;
-                                utf8_code_point = _byte - 0xE0;
-                            } else if (this.inRange(_byte, 0xF0, 0xF4)) {
-                                utf8_bytes_needed = 3;
-                                utf8_lower_boundary = 0x10000;
-                                utf8_code_point = _byte - 0xF0;
-                            } else {
-                                this.decoderError(fatal);
-                            }
-                            utf8_code_point = utf8_code_point * Math.pow(64, utf8_bytes_needed);
-                            code_point = null;
-                        }
-                    } else if (!this.inRange(_byte, 0x80, 0xBF)) {
-                        utf8_code_point = 0;
-                        utf8_bytes_needed = 0;
-                        utf8_bytes_seen = 0;
-                        utf8_lower_boundary = 0;
-                        pos--;
-                        code_point = this.decoderError(fatal, _byte);
-                    } else {
-
-                        utf8_bytes_seen += 1;
-                        utf8_code_point = utf8_code_point + (_byte - 0x80) * Math.pow(64, utf8_bytes_needed - utf8_bytes_seen);
-
-                        if (utf8_bytes_seen !== utf8_bytes_needed) {
-                            code_point = null;
-                        } else {
-
-                            let cp = utf8_code_point;
-                            let lower_boundary = utf8_lower_boundary;
-                            utf8_code_point = 0;
-                            utf8_bytes_needed = 0;
-                            utf8_bytes_seen = 0;
-                            utf8_lower_boundary = 0;
-                            if (this.inRange(cp, lower_boundary, 0x10FFFF) && !this.inRange(cp, 0xD800, 0xDFFF)) {
-                                code_point = cp;
-                            } else {
-                                code_point = this.decoderError(fatal, _byte);
-                            }
-                        }
-
-                    }
-                }
-                //Decode string
-                if (code_point !== null && code_point !== this.EOF_code_point) {
-                    if (code_point <= 0xFFFF) {
-                        if (code_point > 0)result += String.fromCharCode(code_point);
-                    } else {
-                        code_point -= 0x10000;
-                        result += String.fromCharCode(0xD800 + ((code_point >> 10) & 0x3ff));
-                        result += String.fromCharCode(0xDC00 + (code_point & 0x3ff));
-                    }
+        decodeUTF8(buffer: Uint8Array | ArrayLike<number>) {
+            var len = buffer.length;
+            if (len < 1)
+                return "";
+            var parts = null,
+                chunk = [],
+                start = 0,
+                i = 0, // char offset
+                t;     // temporary
+            while (start < len) {
+                t = buffer[start++];
+                if (t < 128)
+                    chunk[i++] = t;
+                else if (t > 191 && t < 224)
+                    chunk[i++] = (t & 31) << 6 | buffer[start++] & 63;
+                else if (t > 239 && t < 365) {
+                    t = ((t & 7) << 18 | (buffer[start++] & 63) << 12 | (buffer[start++] & 63) << 6 | buffer[start++] & 63) - 0x10000;
+                    chunk[i++] = 0xD800 + (t >> 10);
+                    chunk[i++] = 0xDC00 + (t & 1023);
+                } else
+                    chunk[i++] = (t & 15) << 12 | (buffer[start++] & 63) << 6 | buffer[start++] & 63;
+                if (i > 8191) {
+                    (parts || (parts = [])).push(String.fromCharCode.apply(String, chunk));
+                    i = 0;
                 }
             }
-            return result;
-        }
-
-        /**
-         * @private
-         *
-         * @param code_point
-         */
-        private encoderError(code_point) {
-            egret.$error(1026, code_point);
-        }
-
-        /**
-         * @private
-         *
-         * @param fatal
-         * @param opt_code_point
-         * @returns
-         */
-        private decoderError(fatal, opt_code_point?):number {
-            if (fatal) {
-                egret.$error(1027);
+            if (parts) {
+                if (i)
+                    parts.push(String.fromCharCode.apply(String, chunk.slice(0, i)));
+                return parts.join("");
             }
-            return opt_code_point || 0xFFFD;
-        }
-
-        /**
-         * @private
-         */
-        private EOF_byte:number = -1;
-        /**
-         * @private
-         */
-        private EOF_code_point:number = -1;
-
-        /**
-         * @private
-         *
-         * @param a
-         * @param min
-         * @param max
-         */
-        private inRange(a, min, max) {
-            return min <= a && a <= max;
-        }
-
-        /**
-         * @private
-         *
-         * @param n
-         * @param d
-         */
-        private div(n, d) {
-            return Math.floor(n / d);
-        }
-
-        /**
-         * @private
-         *
-         * @param string
-         */
-        private stringToCodePoints(string) {
-            /** @type {Array.<number>} */
-            let cps = [];
-            // Based on http://www.w3.org/TR/WebIDL/#idl-DOMString
-            let i = 0, n = string.length;
-            while (i < string.length) {
-                let c = string.charCodeAt(i);
-                if (!this.inRange(c, 0xD800, 0xDFFF)) {
-                    cps.push(c);
-                } else if (this.inRange(c, 0xDC00, 0xDFFF)) {
-                    cps.push(0xFFFD);
-                } else { // (inRange(c, 0xD800, 0xDBFF))
-                    if (i == n - 1) {
-                        cps.push(0xFFFD);
-                    } else {
-                        let d = string.charCodeAt(i + 1);
-                        if (this.inRange(d, 0xDC00, 0xDFFF)) {
-                            let a = c & 0x3FF;
-                            let b = d & 0x3FF;
-                            i += 1;
-                            cps.push(0x10000 + (a << 10) + b);
-                        } else {
-                            cps.push(0xFFFD);
-                        }
-                    }
-                }
-                i += 1;
-            }
-            return cps;
+            return String.fromCharCode.apply(String, chunk.slice(0, i));
         }
     }
+    let pt = ByteArray.prototype;
+    if (TextDecoder) {//如果有原生的文本编码解析类  浏览器支持状况： http://caniuse.com/#feat=textencoder
+        let td = new TextDecoder();
+        pt.decodeUTF8 = td.decode.bind(td);
+        let te = new TextEncoder();
+        pt.encodeUTF8 = te.encode.bind(te);
+    }
+    interface TextDecoder {
+        decode(buffer: ArrayBufferView, options?: { stream: boolean });
+    }
+    interface TextDecoderConstructor {
+        new (): TextDecoder;
+    }
+    declare var TextDecoder: TextDecoderConstructor;
+    interface TextEncoder {
+        encode(buffer: string, options?: { stream: boolean });
+    }
+    interface TextEncoderConstructor {
+        new (): TextEncoder;
+    }
+    declare var TextEncoder: TextEncoderConstructor;
 }


### PR DESCRIPTION
1. 将一些常量使用typescript的特性`const enum`处理
2. 实现`bufferExtSize`，白鹭原本应该是想做字节扩展的，但是不知何故并未实现此方法，导致如果做大量write操作的时候，会出现一直在创建新的ArrayBuffer，并且将原ArrayBuffer的数据拷贝至新的ArrayBuffer中这样的操作  
支持bufferExtSize后，能把此操作频率降低  
3. 使用一些更快的API代替白鹭的操作，白鹭做字节拷贝时，使用的是`DataView.prototype.setUint32`和`DataView.prototype.setUint8`的API，有javascript执行的循环，并且会多一些判断，而`Uin8Array.prototype.set`原生支持字节数组的拷贝  
使用`Uint8Array[index]`操作符代替`DataView.prototype.setUint8`  
4. 使用https://github.com/dcodeIO/protobuf.js/tree/master/lib/utf8 的方案，代替白鹭现有的utf8字符串解析方案，我想白鹭原本想支持as3中 `readMultiByte(length:number,charSet?:string):string`  
所以使用了 https://github.com/inexorabletash/text-encoding 中的方案  
但不知何原因，放弃了支持。  
那么还使用 先将数据解析成CodePoints数组的方案就有些浪费了  
另外高版本的Android已经原生支持TextDecoder和TextEncoder()，(API支持情况可见： http://caniuse.com/#feat=textencoder ) 所以针对此情况做了优化