### PR TITLE
针对 noScale 增加检查屏幕DPR的处理，以防止资源被canvas缩放，又被DPR缩放的问题

### DIFF
--- a/src/egret/player/ScreenAdapter.ts
+++ b/src/egret/player/ScreenAdapter.ts
@@ -154,28 +154,31 @@ namespace egret.sys {
                     }
                     break;
                 default :
-                    stageWidth = screenWidth;
-                    stageHeight = screenHeight;
+                    //noScale 增加检查屏幕DPR的处理
+                    //native时，白鹭有window对象，devicePixelRatio为undefined，同低版本浏览器一致，使用1处理
+                    const DPR = window.devicePixelRatio || 1;
+                    stageWidth = screenWidth * DPR;
+                    stageHeight = screenHeight * DPR;
                     break;
             }
             //宽高不是2的整数倍会导致图片绘制出现问题
-            if (stageWidth % 2 != 0) {
+            if (stageWidth & 1) {
                 stageWidth += 1;
             }
-            if (stageHeight % 2 != 0) {
+            if (stageHeight & 1) {
                 stageHeight += 1;
             }
-            if(displayWidth % 2 != 0) {
+            if (displayWidth & 1) {
                 displayWidth += 1;
             }
-            if(displayHeight % 2 != 0) {
+            if (displayHeight & 1) {
                 displayHeight += 1;
             }
             return {
-                stageWidth: stageWidth,
-                stageHeight: stageHeight,
-                displayWidth: displayWidth,
-                displayHeight: displayHeight
+                stageWidth,
+                stageHeight,
+                displayWidth,
+                displayHeight
             };
         }
     }

--- a/src/egret/utils/ByteArray.ts
+++ b/src/egret/utils/ByteArray.ts
@@ -178,7 +178,7 @@ namespace egret {
             this.bufferExtSize = bufferExtSize;
             let bytes: Uint8Array, wpos = 0;
             if (buffer) {//有数据，则可写字节数从字节尾开始
-                let uint8: Uint8Array, wpos: number;
+                let uint8: Uint8Array;
                 if (buffer instanceof Uint8Array) {
                     uint8 = buffer;
                     wpos = buffer.length;
@@ -425,22 +425,24 @@ namespace egret {
          * @language zh_CN
          */
         public readBytes(bytes: ByteArray, offset: number = 0, length: number = 0): void {
+            if (!bytes) {//由于bytes不返回，所以new新的无意义
+                return
+            }
+            let pos = this._position;
+            let available = this.write_position - pos;
+            if (available < 0) {
+                egret.$error(1025);
+                return
+            }
             if (length == 0) {
-                length = this.bytesAvailable;
+                length = available;
             }
-            else if (!this.validate(length)) {
-                return;
+            else if (length > available) {
+                egret.$error(1025);
+                return
             }
-            if (bytes) {
-                bytes.validateBuffer(offset + length);
-            }
-            else {
-                bytes = new ByteArray(new ArrayBuffer(offset + length));
-            }
-            //This method is expensive
-            for (let i = 0; i < length; i++) {
-                bytes.data.setUint8(i + offset, this.data.getUint8(this.position++));
-            }
+            bytes.validateBuffer(offset + length);
+            bytes._bytes.set(this._bytes.subarray(pos, pos + length), offset);
         }
 
         /**


### PR DESCRIPTION
1. 当项目使用noScale，做自适应缩放时，在web上，Canvas大小只有通过
https://github.com/egret-labs/egret-core/blob/master/src/egret/web/WebPlayer.ts#L179
```typescript
let screenRect = this.container.getBoundingClientRect();
```
得到的大小，现在主流手机的DPR均至少在2以上。  
这个时候，如果使用的素材超过此尺寸，会在canvas上先被缩小栅格化，然后因为DPR，再使用多个像素绘制单像素。 
导致文本，图像严重失真   
而将Canvas大小设置为屏幕物理尺寸后（即*devicePixelRatio）之后，则能显示正常。

2. 优化stageWidth，stageHeight，displayWidth，displayHeight这4个值进行`偶数判断`的写法