### PR TITLE
减少没必要的合成层

### DIFF
--- a/src/egret/web/WebPlayer.ts
+++ b/src/egret/web/WebPlayer.ts
@@ -140,7 +140,6 @@ namespace egret.web {
             style = container.style;
             style.overflow = "hidden";
             style.position = "relative";
-            style["webkitTransform"] = "translateZ(0)";
         }
 
         private playerOption:PlayerOption;


### PR DESCRIPTION
https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count?hl=zh-cn
“此处的问题是您创建的每一层都需要内存和管理，而这些并不是免费的。事实上，在内存有限的设备上，对性能的影响可能远远超过创建层带来的任何好处。每一层的纹理都需要上传到 GPU，使 CPU 与 GPU 之间的带宽、GPU 上可用于纹理处理的内存都受到进一步限制”