### PR TITLE
修复一个移除事件监听时 this 传入错误的问题

### DIFF
--- a/src/extension/eui/components/Scroller.ts
+++ b/src/extension/eui/components/Scroller.ts
@@ -793,7 +793,7 @@ namespace eui {
             this.removeEventListener(egret.TouchEvent.TOUCH_MOVE, this.onTouchMove, this);
             stage.removeEventListener(egret.TouchEvent.TOUCH_END, this.onTouchEnd, this, true);
             stage.removeEventListener(egret.TouchEvent.TOUCH_MOVE, this.onTouchMove, this);
-            this.removeEventListener(egret.TouchEvent.TOUCH_CANCEL, this.onTouchCancel, true);
+            this.removeEventListener(egret.TouchEvent.TOUCH_CANCEL, this.onTouchCancel, this);
             this.removeEventListener(egret.Event.REMOVED_FROM_STAGE, this.onRemoveListeners, this);
         }
 


### PR DESCRIPTION
eui.Scroller中, 根据上文(629行附近), 此处(796行)应该传入this, 而不是true.