### PR TITLE
	优化性能

### DIFF
--- a/src/egret/web/startTicker
+++ b/src/egret/web/startTicker
@@ -108,7 +108,8 @@ namespace egret.web {
         sys.CanvasRenderBuffer = web.CanvasRenderBuffer;
         setRenderMode(options.renderMode);
         let ticker = egret.sys.$ticker;
-        startTicker(ticker);
+        
+        (ticker);
         if (options.screenAdapter) {
             egret.sys.screenAdapter = options.screenAdapter;
         }

--- a/src/egret/web/startTicker
+++ b/src/egret/web/startTicker
@@ -174,7 +174,7 @@ namespace egret.web {
             };
         }
 
-        requestAnimationFrame.call(window, onTick);
+        requestAnimationFrame(onTick);
         function onTick():void {
 
             if(customContext) {
@@ -182,7 +182,7 @@ namespace egret.web {
             }
 
             ticker.update();
-            requestAnimationFrame.call(window, onTick)
+            requestAnimationFrame(onTick);
         }
     }
 


### PR DESCRIPTION
requestAnimationFrame.call(window, onTick);
这种写法是多余的，没有改变this指向的必要，而且会导致浏览器引擎内部做多余操作。
改成requestAnimationFrame(onTick);一是更直接，二是可以减少浏览器gc频率。