### PR TITLE
优化性能

### DIFF
--- a/src/egret/web/EgretWeb.ts
+++ b/src/egret/web/EgretWeb.ts
@@ -194,7 +194,7 @@ namespace egret.web {
             };
         }
 
-        requestAnimationFrame.call(window, onTick);
+        requestAnimationFrame(onTick);
         function onTick():void {
 
             if(customContext) {
@@ -202,7 +202,7 @@ namespace egret.web {
             }
 
             ticker.update();
-            requestAnimationFrame.call(window, onTick)
+            requestAnimationFrame(onTick);
         }
     }
 


### PR DESCRIPTION
这里通过call方式调用是多余的，而且会导致浏览器引擎内部做多余的操作。
直接调用会更好，而且可以减少浏览器gc频率。