### PR TITLE
修复 egret-core#174编译第三方库minify的bug

### DIFF
--- a/tools/commands/build.ts
+++ b/tools/commands/build.ts
@@ -52,6 +52,7 @@ class Build implements egret.Command {
         let projectDir = egret.args.projectDir;
         let compiler = new Compiler.Compiler();
         let { options, fileNames } = compiler.parseTsconfig(projectDir, egret.args.publish);
+        options.defines = undefined;
         options.emitReflection = true;
         let outFile = options.outFile;
         if (!outFile) {


### PR DESCRIPTION
由于egret-core 4.1.0之后使用 `buildLib2`方法
其中调用`compiler.parseTsconfig`会对`compilerOption`创建一个{DEBUG:true,RELEASE:false}的defines，在编译时会替换所有 `DEBUG`标签为`true`
而 `4.0.3`之前的脚本`buildLib`并不会做此操作
所以将 `options.defines`清空可以解决此问题

closes #174