### PR TITLE
修复在web环境下，BitmapData.create 没有返回 BitmapData 实例的问题。

### DIFF
--- a/src/egret/display/BitmapData.ts
+++ b/src/egret/display/BitmapData.ts
@@ -180,9 +180,12 @@ namespace egret {
                 let img: HTMLImageElement = new Image();
                 img.src = "data:" + imageType + ";base64," + base64;
                 img.crossOrigin = '*';
+                let bitmapData = new BitmapData(img);
                 img.onload = function () {
-                    return new BitmapData(img);
+                    bitmapData.width = img.width;
+                    bitmapData.height = img.height;
                 }
+                return bitmapData;
             }
             else {
                 let buffer: ArrayBuffer = null;


### PR DESCRIPTION
之前的写法并没有把创建出来的 BitmapData 实例返回出去，外部调用 create 会收到 undefined。