### PR TITLE
修正 egret publish 时错误的从 debug/index.html 进行复制的 bug

### DIFF
--- a/tools/commands/publish.js
+++ b/tools/commands/publish.js
@@ -117,7 +117,7 @@ var Publish = (function () {
                                 EgretProject.manager.modifyIndex(manifestPath, indexPath);
                             }
                             else {
-                                FileUtil.copy(FileUtil.joinPath(options.templateDir, "debug", "index.html"), indexPath);
+                                FileUtil.copy(FileUtil.joinPath(options.templateDir, "web", "index.html"), indexPath);
                                 EgretProject.manager.modifyIndex(manifestPath, indexPath);
                             }
                             copyAction = new CopyAction(options.projectDir, options.releaseDir);

--- a/tools/commands/publish.ts
+++ b/tools/commands/publish.ts
@@ -106,7 +106,7 @@ class Publish implements egret.Command {
                 EgretProject.manager.modifyIndex(manifestPath, indexPath);
             }
             else {
-                FileUtil.copy(FileUtil.joinPath(options.templateDir, "debug", "index.html"), indexPath);
+                FileUtil.copy(FileUtil.joinPath(options.templateDir, "web", "index.html"), indexPath);
                 EgretProject.manager.modifyIndex(manifestPath, indexPath);
             }
 


### PR DESCRIPTION
修正 egret publish 时错误的从 debug/index.html 进行复制的 bug，改为从 web/index.html 进行复制