### PR TITLE
修正 RadioButtonGroup.selectedValue = 0 无法正确选中 RadioButton 的 bug

### DIFF
--- a/src/extension/eui/components/RadioButtonGroup.ts
+++ b/src/extension/eui/components/RadioButtonGroup.ts
@@ -340,8 +340,9 @@ namespace eui {
             for (let i = 0; i < length; i++) {
                 buttons[i].$indexNumber = i;
             }
-            if (this._selectedValue)
+            if (this._selectedValue != null) {
                 this.selectedValue = this._selectedValue;
+            }
             if (instance.selected == true)
                 this.selection = instance;
 


### PR DESCRIPTION
在 egret.Event.ADDED_TO_STAGE 之前设置 RadioButtonGroup.selectedValue 会将值保存到 _selectedValue ，如果值为 0， 则会导致 RadioButtonGroup 不能正确的设置状态