### PR TITLE
Update Html5Capatibility.ts

### DIFF
--- a/src/egret/web/Html5Capatibility.ts
+++ b/src/egret/web/Html5Capatibility.ts
@@ -103,7 +103,7 @@ namespace egret.web {
 
             egret.Capabilities.$isMobile = (ua.indexOf('mobile') != -1 || ua.indexOf('android') != -1);
 
-            Html5Capatibility._canUseBlob = false;
+            Html5Capatibility._canUseBlob = !!(window.Blob && window.URL);
             let canUseWebAudio = window["AudioContext"] || window["webkitAudioContext"] || window["mozAudioContext"];
             if (canUseWebAudio) {
                 try {


### PR DESCRIPTION
修复 windows 下，可以使用 blob 但是 _canUseBlob 为 false  
因为之前代码，只针对 ios 和 android 做了处理，而默认值为 false  