### PR TITLE
修复EUI BUG：:当 group 的 sacleX or scaleY ==0 的时候，随便点击哪里都是点击成功

### DIFF
--- a/src/extension/eui/components/Group.ts
+++ b/src/extension/eui/components/Group.ts
@@ -445,7 +445,9 @@ namespace eui {
             if (target || this.$Group[Keys.touchThrough]) {
                 return target;
             }
-            if (!this.$visible || !this.touchEnabled) {
+            //Bug: 当 group.sacleX or scaleY ==0 的时候，随便点击那里都点击成功
+            //虽然 super.$hitTest里面检测过一次 宽高大小，但是没有直接退出这个函数，所以要再判断一次;（width,height可以不判断）
+            if (!this.$visible || !this.touchEnabled || this.scaleX === 0 || this.scaleY === 0 || this.width === 0 || this.height === 0) {
                 return null;
             }
             let point = this.globalToLocal(stageX, stageY, egret.$TempPoint);


### PR DESCRIPTION
# 修复EUI Group 的BUG  v.5.0.x-5.1
 修复BUG:当 group 的 sacleX or scaleY ==0 的时候，随便点击哪里都是点击成功