### PR TITLE
优化Res通过url获取文件类型 的方法

### DIFF
--- a/src/extension/resource/Resource.ts
+++ b/src/extension/resource/Resource.ts
@@ -900,6 +900,10 @@ namespace RES {
         private getTypeByUrl(url:string):string{
             let suffix:string = url.substr(url.lastIndexOf(".")+1);
             if(suffix){
+                let queryParamIndex = suffix.lastIndexOf("?");
+                if(queryParamIndex > -1){
+                    suffix = suffix.substring(0,queryParamIndex);
+                }
                 suffix = suffix.toLowerCase();
             }
             let type:string;


### PR DESCRIPTION
解决如果url如果包含有?query string参数的时候，如果Res.getResByUrl()方法不指定type，只能得到二进制数据的问题。