### PR TITLE
用于处理 #245 的问题 Update Matrix.ts

### DIFF
--- a/src/egret/geom/Matrix.ts
+++ b/src/egret/geom/Matrix.ts
@@ -866,6 +866,8 @@ namespace egret {
             skewY = skewY / DEG_TO_RAD;
             let u = egret.NumberUtils.cos(skewX);
             let v = egret.NumberUtils.sin(skewX);
+            if (scaleX < 0) scaleX = -scaleX;
+            if (scaleY < 0) scaleY = -scaleY;
             if (skewX == skewY) {
                 this.a = u * scaleX;
                 this.b = v * scaleX;


### PR DESCRIPTION
用于处理 #245 的问题
当 matrix `a`或者`d`为负数的时候
会存在 skewX和scaleX 或者 skewY和scaleY 均计算得到赋值的情况  
这个时候重新计算 a 和 d 会导致 `负负得正`的情况