### PR TITLE
使5.1.x在linux环境下可以正常使用

### DIFF
--- a/tools/project/ProjectData.js
+++ b/tools/project/ProjectData.js
@@ -143,7 +143,12 @@ var EgretProjectData = (function () {
             }
             return _path.join(egret.root, 'build', m.name);
         }
-        var egretLibs = getAppDataEnginesRootPath();
+        var egretLibs;
+        if (process.platform === 'linux') {
+            egretLibs = _path.resolve(__dirname, '../../');
+        } else {
+            egretLibs = getAppDataEnginesRootPath();
+        }
         var keyword = '${EGRET_APP_DATA}';
         if (p.indexOf(keyword) >= 0) {
             p = p.replace(keyword, egretLibs);
@@ -271,6 +276,9 @@ var EgretLauncherProxy = (function () {
         };
     };
     EgretLauncherProxy.prototype.getEgretToolsInstalledByVersion = function (checkVersion) {
+        if (process.platform === 'linux') {
+            return _path.resolve(__dirname, '../../');
+        }
         var egretjs = this.getLauncherLibrary();
         var data = egretjs.getAllEngineVersions();
         var versions = [];

--- a/tools/project/ProjectData.ts
+++ b/tools/project/ProjectData.ts
@@ -189,7 +189,12 @@ class EgretProjectData {
             }
             return _path.join(egret.root, 'build', m.name);
         }
-        let egretLibs = getAppDataEnginesRootPath();
+        let egretLibs;
+        if (process.platform === 'linux') {
+            egretLibs = _path.resolve(__dirname, '../../');
+        } else {
+            egretLibs = getAppDataEnginesRootPath();
+        }
         let keyword = '${EGRET_APP_DATA}';
         if (p.indexOf(keyword) >= 0) {
             p = p.replace(keyword, egretLibs);
@@ -343,6 +348,9 @@ class EgretLauncherProxy {
     private proxy: LauncherAPI;
 
     getEgretToolsInstalledByVersion(checkVersion: string) {
+        if (process.platform === 'linux') {
+            return _path.resolve(__dirname, '../../');
+        }
         const egretjs = this.getLauncherLibrary();
         const data = egretjs.getAllEngineVersions() as any[];
         const versions: { version: string, path: string }[] = [];


### PR DESCRIPTION
通过bypass掉egret launcher的检测, 使用当前包里的内容作为引擎.