### PR TITLE
Update Event.ts

### DIFF
--- a/src/egret/events/Event.ts
+++ b/src/egret/events/Event.ts
@@ -724,7 +724,10 @@ namespace egret {
          */
         public static create<T extends Event>(EventClass:{new (type:string, bubbles?:boolean, cancelable?:boolean): T;eventPool?:Event[]},
                                               type:string, bubbles?:boolean, cancelable?:boolean):T {
-            let eventPool:Event[] = EventClass.eventPool;
+            let eventPool:Event[];
+			if(EventClass.hasOwnProperty("eventPool")){
+				eventPool = EventClass.eventPool;
+			}
             if (!eventPool) {
                 eventPool = EventClass.eventPool = [];
             }


### PR DESCRIPTION
ts2.8以后，调整了__extends 的写法，会增加对静态属性的继承`extendStatics`  https://github.com/Microsoft/TypeScript/blob/master/src/compiler/transformers/es2015.ts#L4073-L4082
`TouchEvent`等继承至`Event`的类型，会被`Event`的`eventPool`污染