### PR TITLE
WebGL常量`BYTE`写的有问题，和实际常量值不符合

### DIFF
--- a/src/egret/web/rendering/webgl/EgretWebGLAttribute.ts
+++ b/src/egret/web/rendering/webgl/EgretWebGLAttribute.ts
@@ -32,12 +32,12 @@ namespace egret.web {
     /**
      * @private  
      */
-    export enum WEBGL_ATTRIBUTE_TYPE {
+    export const enum WEBGL_ATTRIBUTE_TYPE {
         FLOAT_VEC2 = 0x8B50,
         FLOAT_VEC3 = 0x8B51,
         FLOAT_VEC4 = 0x8B52,
         FLOAT = 0x1406,
-        BYTE = 0xffff,
+        BYTE = 0x1400,
         UNSIGNED_BYTE = 0x1401,
         UNSIGNED_SHORT = 0x1403
     }

--- a/src/egret/web/rendering/webgl/EgretWebGLUniform.ts
+++ b/src/egret/web/rendering/webgl/EgretWebGLUniform.ts
@@ -32,7 +32,7 @@ namespace egret.web {
     /**
      * @private  
      */
-    export enum WEBGL_UNIFORM_TYPE {
+    export const enum WEBGL_UNIFORM_TYPE {
         FLOAT_VEC2 = 0x8B50,
         FLOAT_VEC3 = 0x8B51,
         FLOAT_VEC4 = 0x8B52,
@@ -48,7 +48,7 @@ namespace egret.web {
         FLOAT_MAT4 = 0x8B5C,
         SAMPLER_2D = 0x8B5E,
         SAMPLER_CUBE = 0x8B60,
-        BYTE = 0xffff,
+        BYTE = 0x1400,
         UNSIGNED_BYTE = 0x1401,
         SHORT = 0x1402,
         UNSIGNED_SHORT = 0x1403,


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants  
中`BYTE`的常量值为：0x1400  
顺便将枚举改为常量枚举，减少编译生成字符串