### PR TITLE
修改XMLHttpRequest load文件失败的判断，在chrome使用加载本地文件的模式下，会出现request.status==0...

### DIFF
--- a/src/egret/media/web/WebAudioSound.ts
+++ b/src/egret/media/web/WebAudioSound.ts
@@ -186,7 +186,7 @@ namespace egret.web {
             request.responseType = "arraybuffer";
             request.onreadystatechange = function () {
                 if (request.readyState == 4) {// 4 = "loaded"
-                    let ioError = (request.status >= 400 || request.status == 0);
+                    let ioError = (request.status >= 400);
                     if (ioError) {//请求错误
                         self.dispatchEventWith(egret.IOErrorEvent.IO_ERROR);
                     } else {

--- a/src/egret/net/web/WebHttpRequest.ts
+++ b/src/egret/net/web/WebHttpRequest.ts
@@ -229,7 +229,7 @@ namespace egret.web {
         private onReadyStateChange():void {
             let xhr = this._xhr;
             if (xhr.readyState == 4) {// 4 = "loaded"
-                let ioError = (xhr.status >= 400 || xhr.status == 0);
+                let ioError = (xhr.status >= 400);
                 let url = this._url;
                 let self = this;
                 window.setTimeout(function ():void {


### PR DESCRIPTION
修改XMLHttpRequest load文件失败的判断，在chrome使用加载本地文件的模式下，会出现request.status==0并且文件是加载成功的情况。所以去掉这个==0的判断。