### PR TITLE
修复linux下执行egret run 报错 missing appdata path

### DIFF
--- a/tools/commands/run.ts
+++ b/tools/commands/run.ts
@@ -19,7 +19,7 @@ class Run implements egret.Command {
     async execute() {
         const exitCode = await new Build().execute();
         const target = egret.args.target;
-        const toolsList = launcher.getLauncherLibrary().getInstalledTools();
+        // const toolsList = launcher.getLauncherLibrary().getInstalledTools();
 
         switch (target) {
             case "web":


### PR DESCRIPTION
#263 
run方法内变量 toolsList 尝试获取egret launch相关程序路径，在linux中没有对应版本程序，导致launcher.getLauncherLibrary() 报错。实际上，下文中也没使用变量toolsList，建议先注释掉。