### PR TITLE
修复严格模式("use strict")下，HTMLTextArea设置type会报错的问题

### DIFF
--- a/src/egret/text/web/HTML5StageText.ts
+++ b/src/egret/text/web/HTML5StageText.ts
@@ -607,9 +607,8 @@ namespace egret.web {
                 inputElement = document.createElement("input");
                 self._simpleElement = inputElement;
                 inputElement.id = "egretInput";
+                inputElement.type = "text";
             }
-
-            inputElement.type = "text";
 
             self._inputDIV.appendChild(inputElement);
             inputElement.setAttribute("tabindex", "-1");


### PR DESCRIPTION
在严格模式下，这段代码会报错  
```
Uncaught TypeError: Cannot assign to read only property 'type' of object '#<HTMLTextAreaElement>'
```
`textarea`也不需要设置`type`属性