### PR TITLE
修复一个ProgressBar的Bug

### DIFF
--- a/src/extension/eui/components/ProgressBar.ts
+++ b/src/extension/eui/components/ProgressBar.ts
@@ -299,7 +299,12 @@ namespace eui {
                 animation.play();
             }
             else {
-                this.animationValue = this.value;
+                if (this.animation.isPlaying) {
+                    this.animation.stop();
+                }
+                this.animationValue = newValue;
+                this.animation.from = newValue;
+                this.animation.currentValue = newValue;
             }
             return result;
         }


### PR DESCRIPTION
修复一个ProgressBar的bug，原来的代码会导致ProgressBar中animation的current状态和from状态没有正确重置，举个例子：
点击一个按钮，使一个ProgressBar从0播放到100%，然后归0
当我第二次点击这个按钮时，会出现先跳了一帧显示100%的，然后再继续从0播放到100% 然后归0

原因是因为，归0的时候，如果此时slideDuration为0，即不缓动，直接设置状态，代码走的是此处的else分支。此时，首先不该将animationValue置为this.value，应该为传进来的参数newValue，其次也应该重置this.animation的from和currentValue。
否则等到this.animation下一次update时，调用到下面的更新回调animationUpdateHandler就会使得this.animationValue被改回未重置的值，在这里例子中，就是100%，所以会出现跳变一帧100%的情况。