### PR TITLE
[eui]修改皮肤类找不到问题

### DIFF
--- a/src/extension/eui/exml/EXML.ts
+++ b/src/extension/eui/exml/EXML.ts
@@ -236,6 +236,9 @@ namespace EXML {
         if (text && text["prototype"]) {
             clazz = text;
         }
+		else if (text && text["paths"]){
+			clazz = text["paths"][url];
+		}
         if (url) {
             if (clazz) {
                 parsedClasses[url] = clazz;


### PR DESCRIPTION
当分离多个.res.json文件，加载第二个res.json时，皮肤类找不到的bug(比如登录模块一个res.json，游戏场景一个res.json，登录完成后在加载第二个res.json，此时会报找不到皮肤。主要是第一个皮肤.thm.json里面用到的皮肤)