### PR TITLE
为调试面板添加元素 id

### DIFF
--- a/src/egret/web/WebFps.ts
+++ b/src/egret/web/WebFps.ts
@@ -61,6 +61,7 @@ namespace egret.web {
                 all.style.left = this.panelX + 'px';
                 all.style.top = this.panelY + 'px';
                 all.style.pointerEvents = 'none';
+                all.id = 'egret-fps-panel';
                 document.body.appendChild(all);
 
                 let container = document.createElement('div');


### PR DESCRIPTION
使得开发者可以动态控制是否显示调试面板