### PR TITLE
fix 修复 tsconfig.json 开启 "noImplicitAny": true 时编译错误的问题。

### DIFF
--- a/build/game/game.d.ts
+++ b/build/game/game.d.ts
@@ -2419,7 +2419,7 @@ declare namespace egret {
      * @includeExample extension/game/utils/setInterval.ts
      * @language zh_CN
      */
-    function setInterval<Z>(listener: (this: Z, ...arg) => void, thisObject: Z, delay: number, ...args: any[]): number;
+    function setInterval<Z>(listener: (this: Z, ...arg: any[]) => void, thisObject: Z, delay: number, ...args: any[]): number;
     /**
      * Clear function to run after a specified delay.
      * @param key {number} Index that egret.setInterval returns
@@ -2463,7 +2463,7 @@ declare namespace egret {
      * @includeExample extension/game/utils/setTimeout.ts
      * @language zh_CN
      */
-    function setTimeout<Z>(listener: (this: Z, ...arg) => void, thisObject: Z, delay: number, ...args: any[]): number;
+    function setTimeout<Z>(listener: (this: Z, ...arg: any[]) => void, thisObject: Z, delay: number, ...args: any[]): number;
     /**
      * Function run after the specified delay is cleared.
      * @param key {number} Index that egret.setTimeout returns


### PR DESCRIPTION
修复 tsconfig.json 开启 "noImplicitAny": true 时编译错误的问题。错误示例如下:
Error D:/Projects/egret/libs/modules/game/game.d.ts (2422,49): Rest parameter 'arg' implicitly has an 'any[]' type.
Error D:/Projects/egret/libs/modules/game/game.d.ts (2466,48): Rest parameter 'arg' implicitly has an 'any[]' type.