### PR TITLE
fix detect iPad device on IOS 13.1.1+

### DIFF
--- a/src/egret/web/WebCapability.ts
+++ b/src/egret/web/WebCapability.ts
@@ -42,7 +42,7 @@ namespace egret.web {
             let ua = navigator.userAgent.toLowerCase();
             capabilities["isMobile" + ""] = (ua.indexOf('mobile') != -1 || ua.indexOf('android') != -1);
             if (capabilities.isMobile) {
-                if (ua.indexOf("windows") < 0 && (ua.indexOf("iphone") != -1 || ua.indexOf("ipad") != -1 || ua.indexOf("ipod") != -1)) {
+                if (ua.indexOf("windows") < 0 && (ua.indexOf("iphone") != -1 || ua.indexOf("ipad") != -1 || ua.indexOf("ipod") != -1 || ua.indexOf("Mac OS X") != -1;)) {
                     capabilities["os" + ""] = "iOS";
                 }
                 else if (ua.indexOf("android") != -1 && ua.indexOf("linux") != -1) {


### PR DESCRIPTION
修复更新ios13.1.1+版本后iPad设备的UA信息的识别=>
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko)"
参考资料：https://stackoverflow.com/questions/58019463