### PR TITLE
修复vivo分包发布失败bug

### DIFF
--- a/tools/templates/empty/scripts/vivogame/vivogame.ts
+++ b/tools/templates/empty/scripts/vivogame/vivogame.ts
@@ -92,6 +92,15 @@ export class VivogamePlugin implements plugins.Command {
         gameJSONContent.thirdEngine.egret = engineVersion
 
         fs.writeFileSync(gameJSONPath, JSON.stringify(gameJSONContent, null, "\t"));
+
+        // 自动生成分包目录的game.js文件
+        if(gameJSONContent.subpackages && gameJSONContent.subpackages.length > 0) {
+            for(var i = 0; i < gameJSONContent.subpackages.length; ++i) {
+                let gameJsPath = path.join(pluginContext.outputDir, gameJSONContent.subpackages[i].root, "game.js");
+                fs.writeFileSync(gameJsPath, "");
+            }
+        }
+
         let isPublish = pluginContext.buildConfig.command == "publish" ? true : false;
         let configArr: any[] = []
         for (var i = 0, len = this.jsFileList.length; i < len; i++) {


### PR DESCRIPTION
设置分包后，会因为分包目录未包含game.js文件导致失败。
修复方案是发布时根据分包配置的目录创建对应的game.js文件。