### PR TITLE
fix: 虚拟列表使用错误的itemRenderer

### DIFF
--- a/src/extension/eui/components/DataGroup.ts
+++ b/src/extension/eui/components/DataGroup.ts
@@ -753,7 +753,7 @@ namespace eui {
             if (!rendererClass) {
                 rendererClass = ItemRenderer;
             }
-            if (!rendererClass.$hashCode) {
+            if (!rendererClass.hasOwnProperty('$hashCode')) {
                 rendererClass.$hashCode = egret.$hashCount++;
             }
             return rendererClass;


### PR DESCRIPTION
当使用eui.ItemRenderer时会给ItemRenderer赋值$hashCode，之后使用其他继承于eui.ItemRenderer的其他ItemRenderer就会直接读取到eui.ItemRenderer的$hashCode，而无法创建新的$hashCode；
最终导致：当虚拟列表使用两个不同的renderer时，由于他们的$hashCode是一样的，所以执行createVirtualRenderer方法时会取之前缓存的renderer，最终所有Item都是同一个renderer